### PR TITLE
Fixed mode card arrangement

### DIFF
--- a/views/stylesheets/fixture.scss
+++ b/views/stylesheets/fixture.scss
@@ -209,12 +209,12 @@ data.checkbox {
       overflow: hidden;
     }
 
-    &:nth-of-type(2n+1) {
+    &:nth-of-type(even) {
       margin-right: .5rem;
       float: left;
       clear: left;
     }
-    &:nth-of-type(2n) {
+    &:nth-of-type(odd) {
       margin-left: .5rem;
       float: right;
       clear: right;


### PR DESCRIPTION
The problem with `:nth-of-type` is, that it only works with tags, not classes. See [mdn docs](https://developer.mozilla.org/de/docs/Web/CSS/:nth-of-type):

> The `:nth-of-type(an+b)` CSS pseudo-class matches an element that has `an+b-1` siblings with the same element name before it in the document tree

If a tag is matched by `:nth-of-type`, it only later checks if it also matches the selector before, e.g. `.card.fixture-mode` in `.card.fixture-mode:nth-of-type`. So it's not possible to match every second `.card`, but only every second `section`. See this [live fiddle showing this problematic](https://jsfiddle.net/dyhf55k5/1/).

We could either keep it like this and toggle between `even` and `odd` every time sections are added/removed before the modes or we introduce another container around the modes.