### PR TITLE
Simplify capability menu in schema

### DIFF
--- a/fixtures/american-dj/quad-phase-hp.json
+++ b/fixtures/american-dj/quad-phase-hp.json
@@ -107,7 +107,7 @@
         {
           "range": [121, 134],
           "name": "No Rotation",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [135, 245],
@@ -116,7 +116,7 @@
         {
           "range": [246, 249],
           "name": "No Rotation",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [250, 255],

--- a/fixtures/cameo/thunder-wash-100-rgb.json
+++ b/fixtures/cameo/thunder-wash-100-rgb.json
@@ -36,7 +36,7 @@
         {
           "range": [11, 255],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         }
       ]
     },
@@ -56,12 +56,12 @@
         {
           "range": [11, 250],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [251, 255],
           "name": "Strobe open",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },
@@ -81,37 +81,37 @@
         {
           "range": [11, 33],
           "name": "Puls random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [34, 56],
           "name": "Ramp up random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [57, 79],
           "name": "Ramp down random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [80, 102],
           "name": "Random Strobe Effect slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [103, 127],
           "name": "Strobe Break Effect 5s-1s",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [128, 250],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [251, 255],
           "name": "Strobe open",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },
@@ -237,7 +237,7 @@
         {
           "range": [6, 255],
           "name": "Mic Sensitivity Low-High",
-          "center": true
+          "menuClick": "center"
         }
       ]
     },

--- a/fixtures/cameo/thunder-wash-100-w.json
+++ b/fixtures/cameo/thunder-wash-100-w.json
@@ -36,7 +36,7 @@
         {
           "range": [11, 255],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         }
       ]
     },
@@ -56,12 +56,12 @@
         {
           "range": [11, 250],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [251, 255],
           "name": "Strobe open",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },
@@ -81,37 +81,37 @@
         {
           "range": [11, 33],
           "name": "Puls random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [34, 56],
           "name": "Ramp up random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [57, 79],
           "name": "Ramp down random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [80, 102],
           "name": "Random Strobe Effect slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [103, 127],
           "name": "Strobe Break Effect 5s-1s",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [128, 250],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [251, 255],
           "name": "Strobe open",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },
@@ -139,7 +139,7 @@
         {
           "range": [6, 255],
           "name": "Mic Sensitivity Low-High",
-          "center": true
+          "menuClick": "center"
         }
       ]
     }

--- a/fixtures/cameo/thunder-wash-600-rgb.json
+++ b/fixtures/cameo/thunder-wash-600-rgb.json
@@ -36,7 +36,7 @@
         {
           "range": [11, 255],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         }
       ]
     },
@@ -56,12 +56,12 @@
         {
           "range": [11, 250],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [251, 255],
           "name": "Strobe open",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },
@@ -81,37 +81,37 @@
         {
           "range": [11, 33],
           "name": "Puls random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [34, 56],
           "name": "Ramp up random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [57, 79],
           "name": "Ramp down random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [80, 102],
           "name": "Random Strobe Effect slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [103, 127],
           "name": "Strobe Break Effect 5s-1s",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [128, 250],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [251, 255],
           "name": "Strobe open",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },
@@ -237,7 +237,7 @@
         {
           "range": [6, 255],
           "name": "Mic Sensitivity Low-High",
-          "center": true
+          "menuClick": "center"
         }
       ]
     },

--- a/fixtures/cameo/thunder-wash-600-w.json
+++ b/fixtures/cameo/thunder-wash-600-w.json
@@ -36,7 +36,7 @@
         {
           "range": [11, 255],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         }
       ]
     },
@@ -56,12 +56,12 @@
         {
           "range": [11, 250],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [251, 255],
           "name": "Strobe open",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },
@@ -81,37 +81,37 @@
         {
           "range": [11, 33],
           "name": "Puls random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [34, 56],
           "name": "Ramp up random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [57, 79],
           "name": "Ramp down random slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [80, 102],
           "name": "Random Strobe Effect slow-fast",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [103, 127],
           "name": "Strobe Break Effect 5s-1s",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [128, 250],
           "name": "Strobe 0Hz-30Hz",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [251, 255],
           "name": "Strobe open",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },
@@ -139,7 +139,7 @@
         {
           "range": [6, 255],
           "name": "Mic Sensitivity Low-High",
-          "center": true
+          "menuClick": "center"
         }
       ]
     },

--- a/fixtures/defaults.js
+++ b/fixtures/defaults.js
@@ -42,8 +42,7 @@ module.exports = {
         {
           "range": [0, 255], // required
           "name": "0-100%", // required
-          "hideInMenu": false,
-          "center": false
+          "menuClick": "start"
         }
       ]
     }

--- a/fixtures/gruft/ventilator.json
+++ b/fixtures/gruft/ventilator.json
@@ -37,17 +37,17 @@
         {
           "range": [5, 119],
           "name": "CCW",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [120, 139],
           "name": "Off",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [140, 254],
           "name": "CW",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [255, 255],

--- a/fixtures/martin/roboscan-812.json
+++ b/fixtures/martin/roboscan-812.json
@@ -73,67 +73,67 @@
           "range": [9, 22],
           "name": "White",
           "color": "#ffffff",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [23, 37],
           "name": "Magenta",
           "color": "#ca1f7b",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [38, 52],
           "name": "Pink",
           "color": "#ffc0cb",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [53, 67],
           "name": "Red",
           "color": "#ff0000",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [68, 82],
           "name": "Orange",
           "color": "#ff7f00",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [83, 97],
           "name": "Amber",
           "color": "#ffbf00",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [98, 112],
           "name": "Yellow",
           "color": "#ffff00",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [113, 127],
           "name": "Light Green",
           "color": "#90ee90",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [128, 142],
           "name": "Green",
           "color": "#00ff00",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [143, 157],
           "name": "Cyan",
           "color": "#00ffff",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [158, 172],
           "name": "Blue",
           "color": "#0000ff",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [173, 184],
@@ -144,73 +144,73 @@
           "range": [185, 189],
           "name": "Blue",
           "color": "#0000ff",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [190, 194],
           "name": "Cyan",
           "color": "#00ffff",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [195, 199],
           "name": "Green",
           "color": "#00ff00",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [200, 204],
           "name": "Light Green",
           "color": "#90ee90",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [205, 209],
           "name": "Yellow",
           "color": "#ffff00",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [210, 214],
           "name": "Amber",
           "color": "#ffbf00",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [215, 219],
           "name": "Orange",
           "color": "#ff7f00",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [220, 224],
           "name": "Red",
           "color": "#ff0000",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [225, 229],
           "name": "Pink",
           "color": "#ffc0cb",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [230, 234],
           "name": "Magenta",
           "color": "#ca1f7b",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [235, 239],
           "name": "White",
           "color": "#ffffff",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [240, 255],
           "name": "Black",
           "color": "#000000",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },
@@ -224,119 +224,119 @@
         {
           "range": [23, 37],
           "name": "Dot",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [38, 52],
           "name": "Line",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [53, 67],
           "name": "Stars",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [68, 82],
           "name": "Triangles",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [83, 97],
           "name": "Star",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [98, 112],
           "name": "Dots",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [113, 127],
           "name": "Bells",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [128, 142],
           "name": "Cone",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [143, 157],
           "name": "Phone",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [158, 172],
           "name": "Window",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [173, 184],
           "name": "Triangle",
-          "center": true
+          "menuClick": "center"
         },
         {
           "range": [185, 189],
           "name": "Window",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [190, 194],
           "name": "Phone",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [195, 199],
           "name": "Cone",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [200, 204],
           "name": "Bells",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [205, 209],
           "name": "Dots",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [210, 214],
           "name": "Star",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [215, 219],
           "name": "Triangles",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [220, 224],
           "name": "Stars",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [225, 229],
           "name": "Line",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [230, 234],
           "name": "Dot",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [235, 239],
           "name": "open",
           "color": "#ffffff",
-          "hideInMenu": true
+          "menuClick": "hidden"
         },
         {
           "range": [240, 255],
           "name": "closed",
           "color": "#000000",
-          "hideInMenu": true
+          "menuClick": "hidden"
         }
       ]
     },

--- a/fixtures/schema.js
+++ b/fixtures/schema.js
@@ -22,7 +22,7 @@ var ISODate = schema(/^\d{4}-\d{2}-\d{2}$/);
 
 var Color = schema(/^#[0-9a-f]{6}$/);
 
-var Category = schema(['Other', 'Color Changer', 'Dimmer', 'Effect', 'Fan', 'Flower', 'Hazer', 'Laser', 'Moving Head', 'Scanner', 'Smoke', 'Strobe', 'Blinder']);
+var Category = schema(['Blinder', 'Color Changer', 'Dimmer', 'Effect', 'Fan', 'Flower', 'Hazer', 'Laser', 'Moving Head', 'Scanner', 'Smoke', 'Strobe', 'Other']);
 
 var Physical = schema({
   '?dimensions': Array.of(3, Number.min(0)), // width, height, depth (in mm)
@@ -52,8 +52,7 @@ var Physical = schema({
 var Capability = schema({
   'range': Array.of(2, DMXValue),
   'name': String,
-  '?hideInMenu': Boolean,
-  '?center': Boolean,
+  '?menuClick': ['start', 'center', 'end', 'hidden'],
   '?color': Color,
   '?color2': Color,
   '?image': String,

--- a/plugins/ecue.js
+++ b/plugins/ecue.js
@@ -181,7 +181,7 @@ function exportHandleModes(fixture, defaults, physical) {
         for (const cap of channel.capabilities) {
           const capData = Object.assign({}, defaults.availableChannels['channel key'].capabilities[0], cap);
 
-          str += `                        <Range Name="${capData.name}" Start="${capData.range[0]}" End="${capData.range[1]}" AutoMenu="${capData.hideInMenu ? 0 : 1}" Centre="${capData.center ? 1 : 0}" />\n`;
+          str += `                        <Range Name="${capData.name}" Start="${capData.range[0]}" End="${capData.range[1]}" AutoMenu="${capData.menuClick == 'hidden' ? 0 : 1}" Centre="${capData.menuClick == 'center' ? 1 : 0}" />\n`;
         }
         str += `                    </Channel${chType}>\n`;
       }
@@ -436,10 +436,10 @@ module.exports.import = function importEcue(str, filename, resolve, reject) {
                 }
 
                 if (range.$.AutoMenu != '1') {
-                  cap.hideInMenu = true;
+                  cap.menuClick = 'hidden';
                 }
-                if (range.$.Centre != '0') {
-                  cap.center = true;
+                else if (range.$.Centre != '0') {
+                  cap.menuClick = 'center';
                 }
 
                 ch.capabilities.push(cap);

--- a/views/pages/single_fixture.js
+++ b/views/pages/single_fixture.js
@@ -80,7 +80,7 @@ module.exports = function(options) {
     str += '</section>';
   }
 
-  if ('multiByteChannel' in fixture || 'heads' in fixture) {
+  if ('multiByteChannels' in fixture || 'heads' in fixture) {
     str += '<h3 class="channel-groups">Channel groups</h3>';
     str += '<section class="channel-groups">';
 
@@ -372,12 +372,8 @@ function handleChannel(channel) {
       str += `  <data data-key="capability-name">${_(cap.name)}</data>`;
       str += `</td>`;
 
-      str += `<td class="capability-hideInMenu" title="hide in menu? ${cap.hideInMenu}">`;
-      str += `  <data class="checkbox" data-key="capability-hideInMenu" data-value="${cap.hideInMenu}">${_(cap.hideInMenu)}</data>`;
-      str += `</td>`;
-
-      str += `<td class="capability-center" title="use center value on menu click? ${cap.center}">`;
-      str += `  <data class="checkbox" data-key="capability-center" data-value="${cap.center}">${_(cap.center)}</data>`;
+      str += `<td class="capability-menuClick" title="menu click action">`;
+      str += `  <data data-key="capability-menuClick">${_(cap.menuClick)}</data>`;
       str += `</td>`;
 
       str += `<td class="capability-color" title="color: ${cap.color}">`;


### PR DESCRIPTION
Instead of two attributes that exclude each other (`center` and `hideInMenu`) and are not easy to understand, use only one with a defined set of possible options (`menuClick` = `start/center/end/hidden`).

Also fix #83 (only a typo).