### PR TITLE
Fix quotation marks in defaults.js

### DIFF
--- a/fixtures/defaults.js
+++ b/fixtures/defaults.js
@@ -1,60 +1,60 @@
 module.exports = {
-  "name": "Fixture name", // required
-  "shortName": null, // default: name
-  "categories": ["Other"], // required
-  "meta": {
-    "authors": [],
-    "createDate": "1970-01-01",
-    "lastModifyDate": "1970-01-01"
+  name: 'Fixture name', // required
+  shortName: null, // default: name
+  categories: ['Other'], // required
+  meta: {
+    authors: [],
+    createDate: '1970-01-01',
+    lastModifyDate: '1970-01-01'
   },
-  "comment": "",
-  "physical": {
-    "dimensions": [0, 0, 0],
-    "weight": 0,
-    "power": 0,
-    "DMXconnector": "3-pin",
-    "bulb": {
-      "type": "",
-      "colorTemperature": 0,
-      "lumens": 0
+  comment: '',
+  physical: {
+    dimensions: [0, 0, 0],
+    weight: 0,
+    power: 0,
+    DMXconnector: '3-pin',
+    bulb: {
+      type: '',
+      colorTemperature: 0,
+      lumens: 0
     },
-    "lens": {
-      "name": "Other",
-      "degreesMinMax": [0, 0]
+    lens: {
+      name: 'Other',
+      degreesMinMax: [0, 0]
     },
-    "focus": {
-      "type": "Fixed",
-      "panMax": 0,
-      "tiltMax": 0
+    focus: {
+      type: 'Fixed',
+      panMax: 0,
+      tiltMax: 0
     }
   },
-  "availableChannels": { // required
-    "channel key": {
-      "name": null, // default: channel key
-      "type": "Intensity", // required
-      "defaultValue": 0,
-      "highlightValue": 0,
-      "invert": false,
-      "constant": false,
-      "crossfade": false,
-      "precedence": "LTP",
-      "capabilities": [
+  availableChannels: { // required
+    'channel key': {
+      name: null, // default: channel key
+      type: 'Intensity', // required
+      defaultValue: 0,
+      highlightValue: 0,
+      invert: false,
+      constant: false,
+      crossfade: false,
+      precedence: 'LTP',
+      capabilities: [
         {
-          "range": [0, 255], // required
-          "name": "0-100%", // required
-          "menuClick": "start"
+          range: [0, 255], // required
+          name: '0-100%', // required
+          menuClick: 'start'
         }
       ]
     }
   },
-  "multiByteChannels": [],
-  "heads": {},
-  "modes": [ // required
+  multiByteChannels: [],
+  heads: {},
+  modes: [ // required
     {
-      "name": "1-channel", // required
-      "shortName": null, // default: name
-      "physical": {},
-      "channels": ["channel key"] // required
+      name: '1-channel', // required
+      shortName: null, // default: name
+      physical: {},
+      channels: ['channel key'] // required
     }
   ]
 };


### PR DESCRIPTION
With renaming `defaults.json` to `default.js`, we don't need quotation marks around properties anymore. However, I still kept them for user-specific content (channel key).

And I switched from double tick `"` to single tick `'` in order to follow the common code style in this project.