### PR TITLE
Handle default.js changes in plugin diff

### DIFF
--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -61,7 +61,7 @@ module.exports = function(args, resolve) {
   const compareArchive = path.join(tempDir, 'compare.zip');
   try {
     childProcess.execSync(
-      `git archive ${args.ref} ${scriptName} ${fixtures.join(' ')} -o ${compareArchive}`,
+      `git archive ${args.ref} ${scriptName} ${fixtures.join(' ')} fixtures/defaults.js -o ${compareArchive}`,
       {
         cwd: path.join(__dirname, '..'),
         encoding: 'utf-8'
@@ -77,25 +77,18 @@ module.exports = function(args, resolve) {
   const unzip = new Zip(fs.readFileSync(compareArchive));
   const unzipDir = path.join(tempDir, 'compareFiles');
   fs.mkdirSync(unzipDir);
-  fs.mkdirSync(path.join(unzipDir, 'fixtures'));
   for (let file in unzip.files) {
     file = unzip.files[file];
     const filePath = path.join(unzipDir, file.name);
 
-    if (!file.dir) {
-      fs.writeFileSync(filePath, file.asNodeBuffer());
-    }
-    else if (!fs.existsSync(filePath)) {
+    if (file.dir) {
       fs.mkdirSync(filePath);
+    }
+    else {
+      fs.writeFileSync(filePath, file.asNodeBuffer());
     }
   }
   del.sync(compareArchive, {force: true});
-
-  // also copy current defaults.js (will be needed by plugin script)
-  fs.writeFileSync(
-    path.join(unzipDir, 'fixtures', 'defaults.js'),
-    fs.readFileSync(path.join(fixtureDir, 'defaults.js'))
-  );
 
   // export with compare plugin script
   exportFixtures(


### PR DESCRIPTION
* [x] Show changes with default.js (use old compare version instead of copying current file)
  * Fixes travis fail in #122
* [ ] Trigger github plugin diff run when default.js changes
  * @FloEdelmann Which fixtures should then be tested with which plugins? All plugins that use default.js with the test fixtures?
  * We could also move this into another issue and merge this PR in order to make #122 mergeable
  * :arrow_right: Moved to #124 
