### PR TITLE
Split fine channel feature into 16 bit and 24+ bit (closes #152)

### DIFF
--- a/cli/fixture-features/fine-channels.js
+++ b/cli/fixture-features/fine-channels.js
@@ -1,0 +1,36 @@
+module.exports = [
+  {
+    id: 'fine-channel-alias',
+    name: 'Fine channels (16bit)',
+    description: 'Whether a channel defines exactly one fine channel alias',
+    order: 81,
+    hasFeature: function(fixture, fineChannels) {
+      for (const ch of Object.keys(fixture.availableChannels)) {
+        const channel = fixture.availableChannels[ch]
+        if ('fineChannelAliases' in channel) {
+          if (channel.fineChannelAliases.length === 1) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+  },
+  {
+    id: 'fine-channel-aliases',
+    name: 'Fine channels (24bit and more)',
+    description: 'Whether a channel defines two or more fine channel aliases',
+    order: 80,
+    hasFeature: function(fixture, fineChannels) {
+      for (const ch of Object.keys(fixture.availableChannels)) {
+        const channel = fixture.availableChannels[ch]
+        if ('fineChannelAliases' in channel) {
+          if (channel.fineChannelAliases.length > 1) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+  }
+];

--- a/cli/fixture-features/fine-channels.js
+++ b/cli/fixture-features/fine-channels.js
@@ -6,7 +6,7 @@ module.exports = [
     order: 81,
     hasFeature: function(fixture, fineChannels) {
       for (const ch of Object.keys(fixture.availableChannels)) {
-        const channel = fixture.availableChannels[ch]
+        const channel = fixture.availableChannels[ch];
         if ('fineChannelAliases' in channel) {
           if (channel.fineChannelAliases.length === 1) {
             return true;
@@ -23,7 +23,7 @@ module.exports = [
     order: 80,
     hasFeature: function(fixture, fineChannels) {
       for (const ch of Object.keys(fixture.availableChannels)) {
-        const channel = fixture.availableChannels[ch]
+        const channel = fixture.availableChannels[ch];
         if ('fineChannelAliases' in channel) {
           if (channel.fineChannelAliases.length > 1) {
             return true;

--- a/cli/fixture-features/fine-channels.js
+++ b/cli/fixture-features/fine-channels.js
@@ -7,10 +7,8 @@ module.exports = [
     hasFeature: function(fixture, fineChannels) {
       for (const ch of Object.keys(fixture.availableChannels)) {
         const channel = fixture.availableChannels[ch];
-        if ('fineChannelAliases' in channel) {
-          if (channel.fineChannelAliases.length === 1) {
-            return true;
-          }
+        if ('fineChannelAliases' in channel && channel.fineChannelAliases.length === 1) {
+          return true;
         }
       }
       return false;
@@ -18,16 +16,14 @@ module.exports = [
   },
   {
     id: 'fine-channel-aliases',
-    name: 'Fine channels (24bit and more)',
+    name: 'Fine channels (>16bit)',
     description: 'Whether a channel defines two or more fine channel aliases',
     order: 80,
     hasFeature: function(fixture, fineChannels) {
       for (const ch of Object.keys(fixture.availableChannels)) {
         const channel = fixture.availableChannels[ch];
-        if ('fineChannelAliases' in channel) {
-          if (channel.fineChannelAliases.length > 1) {
-            return true;
-          }
+        if ('fineChannelAliases' in channel && channel.fineChannelAliases.length > 1) {
+          return true;
         }
       }
       return false;

--- a/cli/fixture-features/uses-fine-channels.js
+++ b/cli/fixture-features/uses-fine-channels.js
@@ -1,8 +1,0 @@
-module.exports = [{
-  name: 'Fine channels',
-  description: 'Whether at least one channel defines fine channel aliases',
-  order: 80,
-  hasFeature: function(fixture, fineChannels) {
-    return Object.keys(fineChannels).length > 0;
-  }
-}];

--- a/tests/test-fixtures.json
+++ b/tests/test-fixtures.json
@@ -17,7 +17,7 @@
     "features": [
       "floating-point-dimensions",
       "floating-point-weight",
-      "uses-fine-channels",
+      "fine-channel-alias",
       "channels-in-multiple-modes"
     ]
   },


### PR DESCRIPTION
Test fixtures haven't changed.

Output with `-a` option:

| | Multiple categories | <abbr title="In fixture physical or in a mode's physical override.">Floating point dimensions ([#133](https://github.com/FloEdelmann/open-fixture-library/issues/133))</abbr> | <abbr title="In fixture physical or in a mode's physical override.">Floating point weight</abbr> | <abbr title="In fixture physical or in a mode's physical override.">Floating point power</abbr> | <abbr title="In fixture physical or in a mode's physical override.">Floating point color temperature</abbr> | <abbr title="In fixture physical or in a mode's physical override.">Floating point lumens</abbr> | <abbr title="In fixture physical or in a mode's physical override.">Floating point lens degrees</abbr> | <abbr title="In fixture physical or in a mode's physical override.">Floating point pan/tilt maximum</abbr> | <abbr title="Whether a channel defines exactly one fine channel alias">Fine channels (16bit)</abbr> | <abbr title="Whether a channel defines two or more fine channel aliases">Fine channels (>16bit)</abbr> | <abbr title="Whether at least one channel defines switching channel aliases">Switching channels</abbr> | Heads | <abbr title="Whether at least one mode uses the 'physical' property">Physical override</abbr> | <abbr title="Whether there is at least one channel that is used in different modes">Reused channels</abbr> | <abbr title="Fine channel used in a mode before its coarse channel">Fine before coarse</abbr> | <abbr title="Channel list of a mode contains null, so it has an unused channel">`null` channels</abbr>
|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-
[*american-dj* **Quad Phase HP**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/american-dj/quad-phase-hp.json) | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x:
[*american-dj* **Revo 4 IR**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/american-dj/revo-4-ir.json) | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x:
[*cameo* **Outdoor PAR Tri 12**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/cameo/outdoor-par-tri-12.json) | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*cameo* **Thunder Wash 100 RGB**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/cameo/thunder-wash-100-rgb.json) | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*cameo* **Thunder Wash 100 W**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/cameo/thunder-wash-100-w.json) | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*cameo* **Thunder Wash 600 RGB**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/cameo/thunder-wash-600-rgb.json) | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*cameo* **Thunder Wash 600 W**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/cameo/thunder-wash-600-w.json) | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :white_check_mark: | :x: | :x:
[*elation* **Platinum HFX**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/elation/platinum-hfx.json) | :x: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*elation* **Platinum Spot 15R Pro**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/elation/platinum-spot-15r-pro.json) | :x: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*eurolite* **LED PAR-56 TCL**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/eurolite/led-par-56-tcl.json) | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*eurolite* **LED PS-4 HCL**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/eurolite/led-ps-4-hcl.json) | :x: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*eurolite* **LED SLS-6 UV Floor**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/eurolite/led-sls-6-uv-floor.json) | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*eurolite* **LED TMH-18**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/eurolite/led-tmh-18.json) | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: | :white_check_mark: | :x: | :x:
[*eurolite* **LED TMH-X25**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/eurolite/led-tmh-x25.json) | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: | :white_check_mark: | :x: | :x:
[*futurelight* **PRO Slim PAR-7 HCL**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/futurelight/pro-slim-par-7-hcl.json) | :x: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: | :x:
[*gruft* **Ventilator**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/gruft/ventilator.json) | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x:
[*lightmaxx* **Platinum Mini TRI-PAR**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/lightmaxx/platinum-mini-tri-par.json) | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x:
[*lightmaxx* **Vega Zoom Wash**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/lightmaxx/vega-zoom-wash.json) | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x:
[*martin* **RoboScan 812**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/martin/roboscan-812.json) | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*showtec* **Phantom 140 LED Beam**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/showtec/phantom-140-led-spot.json) | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
[*showtec* **Phantom 50 LED Spot**](https://github.com/FloEdelmann/open-fixture-library/blob/master/fixtures/showtec/phantom-50-led-spot.json) | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x:
