### PR TITLE
Allow switching to fine channels

### DIFF
--- a/fixtures/schema.js
+++ b/fixtures/schema.js
@@ -51,8 +51,8 @@ var Physical = schema({
 
 var DMXValue = Number.min(0).step(1);  // max value depends on how many fine channels there are (255 if none, 65535 if one, etc.)
 
-var ChannelKey = String;  // channels in availableChannels
-var ChannelAliasKey = String;  // channel keys that are only defined inside other channels
+var ChannelKey = NonEmptyString;  // channels in availableChannels
+var ChannelAliasKey = NonEmptyString;  // channel keys that are only defined inside other channels
 
 var Capability = schema({
   'range': Array.of(2, DMXValue),
@@ -68,7 +68,7 @@ var Capability = schema({
 });
 
 var Channel = schema({
-  '?name': String, // if not set: use channel key
+  '?name': NonEmptyString, // if not set: use channel key
   'type': ['Intensity', 'Strobe', 'Shutter', 'Speed', 'SingleColor', 'MultiColor', 'Gobo', 'Prism', 'Pan', 'Tilt', 'Beam', 'Effect', 'Maintenance', 'Nothing'],
   '?color': ['Red', 'Green', 'Blue', 'Cyan', 'Magenta', 'Yellow', 'Amber', 'White', 'UV', 'Lime', 'Indigo'], // required and only allowed for SingleColor
   '?fineChannelAliases': Array.of(1, Infinity, ChannelAliasKey),

--- a/fixtures/schema.js
+++ b/fixtures/schema.js
@@ -62,7 +62,7 @@ var Capability = schema({
   '?color2': Color,
   '?image': NonEmptyString,
   '?switchChannels': schema({
-    '*': [ChannelKey, ChannelAliasKey] // switch switching channel '*' to an already defined (fine) channel
+    '*': [ChannelKey, ChannelAliasKey] // switch switching channel '*' to an already defined channel or fine channel
   }),
   '*': Function
 });

--- a/fixtures/schema.js
+++ b/fixtures/schema.js
@@ -62,7 +62,7 @@ var Capability = schema({
   '?color2': Color,
   '?image': NonEmptyString,
   '?switchChannels': schema({
-    '*': ChannelKey // switch switching channel '*' to ChannelKey
+    '*': [ChannelKey, ChannelAliasKey] // switch switching channel '*' to an already defined (fine) channel
   }),
   '*': Function
 });

--- a/plugins/ecue.js
+++ b/plugins/ecue.js
@@ -167,23 +167,27 @@ function exportHandleModes(fixture, physical, xmlMan, fineChannels, switchingCha
 
 function exportHandleChannel(fixture, mode, dmxCount, viewPosCount, fineChannels, switchingChannels) {
   let chKey = mode.channels[dmxCount];
-  let channel = fixture.availableChannels[chKey];
 
   let dmxByte0 = dmxCount;
   let dmxByte1 = -1;
 
+  // if this is a switching channel, just use the default channel
   if (chKey in switchingChannels) {
     const triggerChannel = fixture.availableChannels[switchingChannels[chKey]];
     const defaultValue = triggerChannel.defaultValue;
 
     for (const cap of triggerChannel.capabilities) {
       if (cap.range[0] <= defaultValue && defaultValue <= cap.range[1]) {
-        channel = fixture.availableChannels[cap.switchChannels[chKey]];
+        chKey = cap.switchChannels[chKey];
         break;
       }
     }
   }
-  else if (chKey in fineChannels) {
+
+
+  let channel = fixture.availableChannels[chKey];
+
+  if (chKey in fineChannels) {
     // use coarse channel's data
     channel = fixture.availableChannels[fineChannels[chKey]];
 

--- a/plugins/ecue.js
+++ b/plugins/ecue.js
@@ -176,15 +176,11 @@ function exportHandleChannel(fixture, mode, dmxCount, viewPosCount, fineChannels
     const triggerChannel = fixture.availableChannels[switchingChannels[chKey]];
     const defaultValue = triggerChannel.defaultValue;
 
-    for (const cap of triggerChannel.capabilities) {
-      if (cap.range[0] <= defaultValue && defaultValue <= cap.range[1]) {
-        chKey = cap.switchChannels[chKey];
-        break;
-      }
-    }
+    chKey = triggerChannel.capabilities.find(
+      cap => cap.range[0] <= defaultValue && defaultValue <= cap.range[1]
+    ).switchChannels[chKey];
   }
-
-
+  
   let channel = fixture.availableChannels[chKey];
 
   if (chKey in fineChannels) {
@@ -223,7 +219,7 @@ function exportHandleChannel(fixture, mode, dmxCount, viewPosCount, fineChannels
   dmxByte1++;
 
   if (!('name' in channel)) {
-    channel.name = chKey;
+    channel.name = mode.channels[dmxCount];
   }
 
   let chData = Object.assign({}, defaults.availableChannels['channel key'], channel);

--- a/tests/fixture_valid.js
+++ b/tests/fixture_valid.js
@@ -169,7 +169,8 @@ module.exports.checkFixture = function checkFixture(fixture, usedShortNames=[]) 
               const switchToChannel = cap.switchChannels[alias];
 
               // check existence
-              if (!(switchToChannel in fixture.availableChannels)) {
+              if (!(switchToChannel in fixture.availableChannels)
+                && !(switchToChannel in fineChannels)) {
                 result.errors.push(`channel '${switchToChannel}' is referenced from capability '${cap.name}' (#${i+1}) in channel '${ch}' but is not defined.`);
               }
 

--- a/tests/fixture_valid.js
+++ b/tests/fixture_valid.js
@@ -233,10 +233,17 @@ module.exports.checkFixture = function checkFixture(fixture, usedShortNames=[]) 
           if (!mode.channels.includes(fineChannels[ch])) {
             result.errors.push(`Mode '${modeShortName}' contains the fine channel '${ch}' (#${chNumber}) but is missing its coarse channel '${coarseChannelKey}'.`);
           }
-          // the mode must also contain all coarser channel
+          // the mode must also contain all coarser channels
           for (let fineIndex = 0; fineIndex < fineChannelAliases.indexOf(ch); fineIndex++) {
             let coarserChannelKey = fineChannelAliases[fineIndex];
-            if (!mode.channels.includes(coarserChannelKey)) {
+
+            // check if the coarse channel is used directly or as part of a switching channel
+            if (!mode.channels.some(
+              chKey => chKey === coarserChannelKey ||
+                (chKey in switchingChannels && fixture.availableChannels[switchingChannels[chKey]].capabilities.some(
+                  cap => Object.keys(cap.switchChannels).some(key => cap.switchChannels[key] === coarserChannelKey)
+                ))
+            )) {
               result.errors.push(`Mode '${modeShortName}' contains the fine channel '${ch}' (#${chNumber}) but is missing its coarser channel '${coarserChannelKey}'.`);
             }
           }

--- a/tests/fixture_valid.js
+++ b/tests/fixture_valid.js
@@ -321,14 +321,14 @@ function checkCoarseChannelExistence(result, fixture, fineChannels, switchingCha
   for (const coarserChannelKey of coarserChannelKeys) {
     // check if the coarse channel is used directly or as part of a switching channel
     const isCoarseUsedInMode = mode.channels.some(chKey => {
-      // used in a switching channel
-      if (chKey in switchingChannels) {
-        const switchedChannels = switchingChannels[chKey].switchedChannels;
-        return switchedChannels.includes(coarserChannelKey)
+      // used directly
+      if (!(chKey in switchingChannels)) {
+        return chKey === coarserChannelKey;
       }
 
-      // used directly
-      return chKey === coarserChannelKey;
+      // used in a switching channel
+      const switchedChannels = switchingChannels[chKey].switchedChannels;
+      return switchedChannels.includes(coarserChannelKey)
     });
     if (!isCoarseUsedInMode) {
       result.errors.push(`Mode '${mode.name || mode.shortName}' contains the fine channel '${ch}' (#${chNumber}) but is missing its coarser channel '${coarserChannelKey}'.`);

--- a/tests/fixture_valid.js
+++ b/tests/fixture_valid.js
@@ -240,7 +240,7 @@ module.exports.checkFixture = function checkFixture(fixture, usedShortNames=[]) 
         // or it is a fine channel
         if (ch in fineChannels) {
           // the mode must contain coarser channels
-          checkCoarseChannelExistence(result, fixture, fineChannels, switchingChannels, ch, mode, chNumber)
+          checkCoarseChannelExistence(result, fixture, fineChannels, switchingChannels, ch, mode, chNumber);
           continue;
         }
 
@@ -256,7 +256,7 @@ module.exports.checkFixture = function checkFixture(fixture, usedShortNames=[]) 
           // if the channel can be switched to a fine channel, the mode must also contain coarser channels
           const switchedFineChannels = switchingChannels[ch].switchedChannels.filter(switchTo => switchTo in fineChannels);
           for (const fineAlias of switchedFineChannels) {
-            checkCoarseChannelExistence(result, fixture, fineChannels, switchingChannels, fineAlias, mode, chNumber)
+            checkCoarseChannelExistence(result, fixture, fineChannels, switchingChannels, fineAlias, mode, chNumber);
           }
 
           continue;
@@ -328,7 +328,7 @@ function checkCoarseChannelExistence(result, fixture, fineChannels, switchingCha
 
       // used in a switching channel
       const switchedChannels = switchingChannels[chKey].switchedChannels;
-      return switchedChannels.includes(coarserChannelKey)
+      return switchedChannels.includes(coarserChannelKey);
     });
     if (!isCoarseUsedInMode) {
       result.errors.push(`Mode '${mode.name || mode.shortName}' contains the fine channel '${ch}' (#${chNumber}) but is missing its coarser channel '${coarserChannelKey}'.`);

--- a/tests/fixture_valid.js
+++ b/tests/fixture_valid.js
@@ -313,15 +313,11 @@ module.exports.checkFixture = function checkFixture(fixture, usedShortNames=[]) 
 
 function checkCoarseChannelExistence(result, fixture, fineChannels, switchingChannels, ch, mode, chNumber) {
   const coarseChannelKey = fineChannels[ch];
-
-  // the mode must also contain the coarse channel
-  if (!mode.channels.includes(coarseChannelKey)) {
-    result.errors.push(`Mode '${mode.name || mode.shortName}' contains the fine channel '${ch}' (#${chNumber}) but is missing its coarse channel '${coarseChannelKey}'.`);
-  }
-
-  // the mode must also contain all coarser channels
   const fineChannelAliases = fixture.availableChannels[coarseChannelKey].fineChannelAliases;
-  const coarserChannelKeys = fineChannelAliases.slice(0, fineChannelAliases.indexOf(ch));
+  const coarserChannelKeys = [coarseChannelKey].concat(
+    fineChannelAliases.slice(0, fineChannelAliases.indexOf(ch))
+  );
+
   for (const coarserChannelKey of coarserChannelKeys) {
     // check if the coarse channel is used directly or as part of a switching channel
     const isCoarseUsedInMode = mode.channels.some(chKey => {

--- a/views/pages/single_fixture.js
+++ b/views/pages/single_fixture.js
@@ -376,16 +376,20 @@ function handleChannel(channel, mode, switchingChannels) {
   }
 
   if ('fineChannelAliases' in channel) {
-    const fineChannelPositions = channel.fineChannelAliases.map(
-      fineAlias => mode.channels.findIndex(
-        chKey => chKey === fineAlias ||
-          (chKey in switchingChannels && switchingChannels[chKey].switchedChannels.includes(fineAlias))
-      ) + 1
-    )
-    // the tests make sure that only the first x finenesses can be used in a mode
-    // -> it's not possible that a mode contains 8bit and 24bit but no 16bit
-    // therefore we can safely assume that the fine channel aliases' indices haven't changed after filtering out finer channels in the end of the array
-    .filter(position => position !== 0);
+    const fineChannelPositions = channel.fineChannelAliases.map(fineAlias => {
+      const index = mode.channels.findIndex(chKey => {
+        // used in a switching channel
+        if (chKey in switchingChannels) {
+          const switchedChannels = switchingChannels[chKey].switchedChannels;
+          return switchedChannels.includes(fineAlias)
+        }
+
+        // used directly
+        return chKey === fineAlias;
+      });
+      return index+1;
+    })
+    .filter(position => position !== 0); // filter out not used finer channels in the end of the array
 
     if (fineChannelPositions.length > 0) {
       str += '<section class="channel-fineChannelAliases">';

--- a/views/pages/single_fixture.js
+++ b/views/pages/single_fixture.js
@@ -393,7 +393,7 @@ function handleChannel(channel, mode, switchingChannels) {
       str += '  <span class="value"><data data-key="channel-fineChannelAliases">';
       str += fineChannelPositions.map((position, index) => {
         const fineAlias = channel.fineChannelAliases[index];
-        return getChannelHeading(fineAlias) + ` (channel ${position})`
+        return getChannelHeading(fineAlias) + ` (channel ${position})`;
       }).join(', ');
       str += '</data></span>';
       str += '</section>';

--- a/views/pages/single_fixture.js
+++ b/views/pages/single_fixture.js
@@ -507,7 +507,7 @@ function getChannelIndexInMode(ch, mode, switchingChannels) {
 
     // used in a switching channel
     const switchedChannels = switchingChannels[chKey].switchedChannels;
-    return switchedChannels.includes(ch)
+    return switchedChannels.includes(ch);
   });
 }
 

--- a/views/pages/single_fixture.js
+++ b/views/pages/single_fixture.js
@@ -500,14 +500,14 @@ function handleFineChannel(coarseChannel, mode, switchingChannels) {
 
 function getChannelIndexInMode(ch, mode, switchingChannels) {
   return mode.channels.findIndex(chKey => {
-    // used in a switching channel
-    if (chKey in switchingChannels) {
-      const switchedChannels = switchingChannels[chKey].switchedChannels;
-      return switchedChannels.includes(ch)
+    // used directly
+    if (!(chKey in switchingChannels)) {
+      return chKey === ch;
     }
 
-    // used directly
-    return chKey === ch;
+    // used in a switching channel
+    const switchedChannels = switchingChannels[chKey].switchedChannels;
+    return switchedChannels.includes(ch)
   });
 }
 

--- a/views/pages/single_fixture.js
+++ b/views/pages/single_fixture.js
@@ -376,7 +376,8 @@ function handleChannel(channel, mode, switchingChannels) {
   }
 
   if ('fineChannelAliases' in channel) {
-    const fineChannelPositions = channel.fineChannelAliases.map(fineAlias => getChannelIndexInMode(fineAlias, mode, switchingChannels) + 1
+    const fineChannelPositions = channel.fineChannelAliases.map(
+      fineAlias => getChannelIndexInMode(fineAlias, mode, switchingChannels) + 1
     ).filter(position => position !== 0); // filter out not used finer channels in the end of the array
 
     if (fineChannelPositions.length > 0) {


### PR DESCRIPTION
The model doesn't need to be updated. QLC+ doesn't support switching fine channels yet, but this will be implemented with #170 and as we don't have fixtures that use this functionality (before merging #172), we can safely merge this PR.