### PR TITLE
Make QLC+ file names one-dimensional

### DIFF
--- a/fixtures/5star-systems/spica-250m.json
+++ b/fixtures/5star-systems/spica-250m.json
@@ -7,7 +7,7 @@
     "createDate": "2017-01-23",
     "lastModifyDate": "2017-07-15",
     "importPlugin": {
-      "plugin": "qlcplus",
+      "plugin": "ecue",
       "date": "2017-01-23"
     }
   },

--- a/plugins/qlcplus/export.js
+++ b/plugins/qlcplus/export.js
@@ -37,7 +37,7 @@ module.exports.export = function exportQLCplus(fixtures, options) {
 
     xml.doctype('');
     return {
-      name: sanitize(fixture.manufacturer.name + '-' + fixture.name + '.qxf').replace(/ /g, '-'),
+      name: sanitize(fixture.manufacturer.name + '-' + fixture.name + '.qxf').replace(/\s+/g, '-'),
       content: xml.end({
         pretty: true,
         indent: ' '

--- a/plugins/qlcplus/export.js
+++ b/plugins/qlcplus/export.js
@@ -1,4 +1,5 @@
 const xmlbuilder = require('xmlbuilder');
+const sanitize = require('sanitize-filename');
 
 const FineChannel = require('../../lib/model/FineChannel.js');
 const SwitchingChannel = require('../../lib/model/SwitchingChannel.js');
@@ -36,7 +37,7 @@ module.exports.export = function exportQLCplus(fixtures, options) {
 
     xml.doctype('');
     return {
-      name: fixture.manufacturer.key + '/' + fixture.key + '.qxf',
+      name: sanitize(fixture.manufacturer.name + '-' + fixture.name + '.qxf').replace(/ /g, '-'),
       content: xml.end({
         pretty: true,
         indent: ' '


### PR DESCRIPTION
The fixtures folder in qlcplus doens't recognize subfolders