### PR TITLE
Increment schema version as of #235

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -2,7 +2,18 @@
 
 Note that this fixture format is not intended to be used directly, as it has no way of versioning and may change without notice.
 
-The [JS Schema](https://github.com/molnarg/js-schema) can be found in the [schema.js](schema.js) file. See there for the details of allowed properties or values. The purpose of this document is to give a high-level overview of the concepts used.
+The purpose of this document is to give a high-level overview of the concepts used. The schema provides all the details about the JSON structure.
+
+## Schema
+
+The [JS Schema](https://github.com/molnarg/js-schema) can be found in the [schema.js](schema.js) file. It is a declarative way to describe allowed properties and values. The [Fixture Validator](../tests/fixtures-valid.js) automatically checks the fixtures against this schema.
+
+The schema exports a property `VERSION`. Everytime the schema is updated, this version needs to be incremented using [semantic versioning](http://semver.org).
+
+Given a version number MAJOR.MINOR.PATCH, increment the:
+1. MAJOR version when you make incompatible API changes,
+2. MINOR version when you add functionality in a backwards-compatible manner, and
+3. PATCH version when you make backwards-compatible bug fixes.
 
 
 ## Goals

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -6,12 +6,12 @@ The purpose of this document is to give a high-level overview of the concepts us
 
 ## Schema
 
-The [JS Schema](https://github.com/molnarg/js-schema) can be found in the [schema.js](schema.js) file. It is a declarative way to describe allowed properties and values. The [Fixture Validator](../tests/fixtures-valid.js) automatically checks the fixtures against this schema.
+The [JS Schema](https://github.com/molnarg/js-schema) can be found in the [schema.js](schema.js) file. It is a declarative way to describe allowed properties and values. The [Fixture Validator](../tests/fixtures-valid.js) automatically checks the fixtures against this schema and does some more tests programatically.
 
 The schema exports a property `VERSION`. Everytime the schema is updated, this version needs to be incremented using [semantic versioning](http://semver.org).
 
 Given a version number MAJOR.MINOR.PATCH, increment the:
-1. MAJOR version when you make incompatible API changes,
+1. MAJOR version when you make incompatible schema changes,
 2. MINOR version when you add functionality in a backwards-compatible manner, and
 3. PATCH version when you make backwards-compatible bug fixes.
 

--- a/fixtures/schema.js
+++ b/fixtures/schema.js
@@ -4,7 +4,7 @@ const schema = require('js-schema');
  * Everytime we update the schema, this version needs to be incremented using semantic versionsing.
  * 
  * Given a version number MAJOR.MINOR.PATCH, increment the:
- * 1. MAJOR version when you make incompatible API changes,
+ * 1. MAJOR version when you make incompatible schema changes,
  * 2. MINOR version when you add functionality in a backwards-compatible manner, and
  * 3. PATCH version when you make backwards-compatible bug fixes.
  * 

--- a/fixtures/schema.js
+++ b/fixtures/schema.js
@@ -1,6 +1,18 @@
 const schema = require('js-schema');
 
-module.exports.VERSION = '1.0.0';
+/**
+ * Everytime we update the schema, this version needs to be incremented using semantic versionsing.
+ * 
+ * Given a version number MAJOR.MINOR.PATCH, increment the:
+ * 1. MAJOR version when you make incompatible API changes,
+ * 2. MINOR version when you add functionality in a backwards-compatible manner, and
+ * 3. PATCH version when you make backwards-compatible bug fixes.
+ * 
+ * See http://semver.org
+ * 
+ * @type {string}
+ */
+module.exports.VERSION = '2.0.0';
 
 /**
  * see https://github.com/molnarg/js-schema


### PR DESCRIPTION
And update docs.

## Changelog for 2.0.0

### Incompatible schema changes

- Renamed channel type `SingleColor` to `Single Color`
- Renamed channel type `MultiColor` to `Multi-Color`

### Backwards-compatible schema changes

- New channel type `Color Temperature`
- New channel type `Fog`
- Allow multilines in comments (match RegEx `/.+/m`)