### PR TITLE
Fix addFixture's propExistsIn

### DIFF
--- a/fixtures/schema.js
+++ b/fixtures/schema.js
@@ -12,7 +12,7 @@ const schema = require('js-schema');
  *
  * @type {string}
  */
-module.exports.VERSION = '3.0.1';
+module.exports.VERSION = '3.0.0';
 
 /**
  * see https://github.com/molnarg/js-schema

--- a/fixtures/schema.js
+++ b/fixtures/schema.js
@@ -12,7 +12,7 @@ const schema = require('js-schema');
  *
  * @type {string}
  */
-module.exports.VERSION = '3.0.0';
+module.exports.VERSION = '3.0.1';
 
 /**
  * see https://github.com/molnarg/js-schema
@@ -255,10 +255,11 @@ const properties = {
   URL:                     URL.toJSON(),
   DMXValue:                DMXValue.toJSON()
 };
-properties.meta  = properties.fixture.meta.properties;
-properties.bulb  = properties.physical.bulb.properties;
-properties.lens  = properties.physical.lens.properties;
-properties.focus = properties.physical.focus.properties;
+properties.meta         = properties.fixture.meta.properties;
+properties.bulb         = properties.physical.bulb.properties;
+properties.lens         = properties.physical.lens.properties;
+properties.focus        = properties.physical.focus.properties;
+properties.matrixPixels = properties.physical.matrixPixels.properties;
 /* eslint-enable key-spacing */
 
 module.exports.properties = properties;

--- a/lib/add-fixtures.js
+++ b/lib/add-fixtures.js
@@ -298,7 +298,7 @@ function isEmptyObject(object) {
 /**
  * @param {?Any} prop The property key to check.
  * @param {?object} object The object to check. If it's null, false is returned.
- * @returns {!boolean} Whether the given property key is present in the object and its value is non-null and non-empty.y
+ * @returns {!boolean} Whether the given property key is present in the object and its value is non-null and non-empty.
  */
 function propExistsIn(prop, object) {
   return object && object[prop];

--- a/lib/add-fixtures.js
+++ b/lib/add-fixtures.js
@@ -287,12 +287,21 @@ function addMode(fixKey, from) {
 
 // helper functions
 
+/**
+ * @param {?object} object The object to check.
+ * @returns {!boolean} Whether the given object literal has no own properties, i.e. that its JSON equivalent is '{}'
+ */
 function isEmptyObject(object) {
   return JSON.stringify(object) === '{}';
 }
 
+/**
+ * @param {?Any} prop The property key to check.
+ * @param {?object} object The object to check. If it's null, false is returned.
+ * @returns {!boolean} Whether the given property key is present in the object and its value is non-null and non-empty.y
+ */
 function propExistsIn(prop, object) {
-  return object[prop] != null && object[prop] !== '';
+  return object && object[prop];
 }
 
 function getComboboxInput(prop, from) {

--- a/lib/add-fixtures.js
+++ b/lib/add-fixtures.js
@@ -296,7 +296,7 @@ function isEmptyObject(object) {
 }
 
 /**
- * @param {?Any} prop The property key to check.
+ * @param {*} prop The property key to check.
  * @param {?object} object The object to check. If it's null, false is returned.
  * @returns {!boolean} Whether the given property key is present in the object and its value is non-null and non-empty.
  */

--- a/lib/add-fixtures.js
+++ b/lib/add-fixtures.js
@@ -301,7 +301,9 @@ function isEmptyObject(object) {
  * @returns {!boolean} Whether the given property key is present in the object and its value is non-null and non-empty.
  */
 function propExistsIn(prop, object) {
-  return object && object[prop];
+  const objectValid = object !== undefined && object !== null;
+  const valueValid = objectValid && object[prop] !== undefined && object[prop] !== null && object[prop] !== '';
+  return valueValid;
 }
 
 function getComboboxInput(prop, from) {


### PR DESCRIPTION
This is a fix for #362:

As the schema also has a matrixPixels object in physical, `propExistsIn` [is called](https://github.com/FloEdelmann/open-fixture-library/blob/a92984ec492f1155b60a541633e875acf98564f8/lib/add-fixtures.js#L159) with the first subProp of matrixPixels as `prop` (which is `'dimensions'`) and the editor's `physical.matrixPixels` object as `object` (which is `undefined`). This causes the exception.

One possible solution would have been including the matrixPixels object in the editor's created fixture, but I decided to edit `propExistsIn` that it doesn't crash on undefined objects. I also simplified the null, undefined and empty checks using the truthy conversion and added a JSDoc comment. (Before, if `object[prop]` was undefined, `true` would be returned as `undefined` equals neither `null` nor `''`)

I also added `matrixPixels`' properties as shorthand to the schema like `focus`, `lens` and `bulb`. It doesn't solve the issue and probably also isn't related to the `addFixtures` module, but it is consistent and will be used by the editor as soon as it supports matrices.