### PR TITLE
Fix QLC+'s head information

### DIFF
--- a/fixtures/showtec/pixel-bar-12-mkii.json
+++ b/fixtures/showtec/pixel-bar-12-mkii.json
@@ -22,7 +22,11 @@
     }
   },
   "matrix": {
-    "pixelCount": [12, 1, 1],
+    "pixelKeys": [
+      [
+        ["12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1"]
+      ]
+    ],
     "pixelGroups": {
       "Master": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"],
       "1/2": ["1", "2", "3", "4", "5", "6"],
@@ -465,7 +469,7 @@
       "channels": [
         {
           "insert": "matrixChannels",
-          "repeatFor": "eachPixelXYZ",
+          "repeatFor": "eachPixelABC",
           "channelOrder": "perPixel",
           "templateChannels": [
             "Red $pixelKey",

--- a/lib/model/Matrix.js
+++ b/lib/model/Matrix.js
@@ -190,6 +190,32 @@ module.exports = class Matrix {
   }
 
   /**
+   * Sorts the pixelKeys by given X/Y/Z order. Order of the parameters equals the order in a repeatFor's "eachPixelXYZ".
+   * @param {('X'|'Y'|'Z')} firstAxis Axis with highest ordering.
+   * @param {('X'|'Y'|'Z')} secondAxis Axis with middle ordering.
+   * @param {('X'|'Y'|'Z')} thirdAxis Axis with lowest ordering.
+   * @returns {!Array.<String>} All pixelKeys ordered by given axis order.
+   */
+  getPixelKeysByOrder(firstAxis, secondAxis, thirdAxis) {
+    const axisToPosIndex = {X: 0, Y: 1, Z: 2};
+    const firstPosIndex = axisToPosIndex[firstAxis];
+    const secondPosIndex = axisToPosIndex[secondAxis];
+    const thirdPosIndex = axisToPosIndex[thirdAxis];
+ 
+    return this.pixelKeys.sort((keyA, keyB) => {
+      const [posA, posB] = [this.pixelKeyPositions[keyA], this.pixelKeyPositions[keyB]];
+ 
+      if (posA[thirdPosIndex] !== posB[thirdPosIndex]) {
+        return posA[thirdPosIndex] - posB[thirdPosIndex];
+      }
+      if (posA[secondPosIndex] !== posB[secondPosIndex]) {
+        return posA[secondPosIndex] - posB[secondPosIndex];
+      }
+      return posA[firstPosIndex] - posB[firstPosIndex];
+    });
+  }
+
+  /**
    * @returns {object.<string, number[]>} Each pixelKey pointing to an array of its X/Y/Z position
    */
   get pixelKeyPositions() {

--- a/lib/model/Matrix.js
+++ b/lib/model/Matrix.js
@@ -201,10 +201,10 @@ module.exports = class Matrix {
     const firstPosIndex = axisToPosIndex[firstAxis];
     const secondPosIndex = axisToPosIndex[secondAxis];
     const thirdPosIndex = axisToPosIndex[thirdAxis];
- 
+
     return this.pixelKeys.sort((keyA, keyB) => {
       const [posA, posB] = [this.pixelKeyPositions[keyA], this.pixelKeyPositions[keyB]];
- 
+
       if (posA[thirdPosIndex] !== posB[thirdPosIndex]) {
         return posA[thirdPosIndex] - posB[thirdPosIndex];
       }

--- a/lib/model/Mode.js
+++ b/lib/model/Mode.js
@@ -1,6 +1,21 @@
-const Physical = require(`./Physical.js`);
-const SwitchingChannel = require(`./SwitchingChannel.js`);
-const TemplateChannel = require(`./TemplateChannel.js`);
+/* eslint-disable no-unused-vars */
+const AbstractChannel = require(`../../lib/model/AbstractChannel.js`);
+const Capability = require(`../../lib/model/Capability.js`);
+const Channel = require(`../../lib/model/Channel.js`);
+const FineChannel = require(`../../lib/model/FineChannel.js`);
+const Fixture = require(`../../lib/model/Fixture.js`);
+const Manufacturer = require(`../../lib/model/Manufacturer.js`);
+const Matrix = require(`../../lib/model/Matrix.js`);
+const MatrixChannel = require(`../../lib/model/MatrixChannel.js`);
+const MatrixChannelReference = require(`../../lib/model/MatrixChannelReference.js`);
+const Meta = require(`../../lib/model/Meta.js`);
+const Mode = require(`../../lib/model/Mode.js`);
+const NullChannel = require(`../../lib/model/NullChannel.js`);
+const Physical = require(`../../lib/model/Physical.js`);
+const Range = require(`../../lib/model/Range.js`);
+const SwitchingChannel = require(`../../lib/model/SwitchingChannel.js`);
+const TemplateChannel = require(`../../lib/model/TemplateChannel.js`);
+/* eslint-enable no-unused-vars */
 
 module.exports = class Mode {
   constructor(jsonObject, fixture) {
@@ -55,7 +70,9 @@ module.exports = class Mode {
     return this._cache.physicalOverride;
   }
 
-  // fixture's physical with mode's physical override applied on
+  /**
+   * @returns {?Physical} Fixture's physical with mode's physical override (if present) applied on
+   */
   get physical() {
     if (!(`physical` in this._cache)) {
       if (this.fixture.physical === null) {
@@ -168,21 +185,7 @@ module.exports = class Mode {
 
     // eachPixelXYZ, eachPixelZYX, ...
     const orderByAxes = repeatFor.replace(`eachPixel`, ``).split(``); // eachPixelYXZ -> ['Y', 'X', 'Z']
-    const [firstPosIndex, secondPosIndex, thirdPosIndex] = orderByAxes.map(
-      axis => ({X: 0, Y: 1, Z: 2}[axis])
-    ); // ['Y', 'X', 'Z'] -> [1, 0, 2]
-
-    return matrix.pixelKeys.sort((keyA, keyB) => {
-      const [posA, posB] = [matrix.pixelKeyPositions[keyA], matrix.pixelKeyPositions[keyB]];
-
-      if (posA[thirdPosIndex] !== posB[thirdPosIndex]) {
-        return posA[thirdPosIndex] - posB[thirdPosIndex];
-      }
-      if (posA[secondPosIndex] !== posB[secondPosIndex]) {
-        return posA[secondPosIndex] - posB[secondPosIndex];
-      }
-      return posA[firstPosIndex] - posB[firstPosIndex];
-    });
+    return matrix.getPixelKeysByOrder(orderByAxes[0], orderByAxes[1], orderByAxes[2]);
   }
 
   /**


### PR DESCRIPTION
- Use XYZ pixel order
- Break pixel groups apart pixel keys
- Reverse Showtec Pixel Bar's pixel order